### PR TITLE
add field/value matching for timeseries

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,20 @@ Select ``timeseries`` Query, and edit Target.
 Example
 
 ```
-fluentd.memory.{memory, time}
+fluentd.memory.{memory,time}
 ```
+
+
+You can also add a match query on a field
+```
+[Database name].[Collection name].{[value column(Y-axis) name],[time column(X-axis) name],[field name],[value to match]}
+```
+Example
+
+```
+fluentd.memory.{memory,time,server,JP}
+```
+
 
 #### Table Query
 Select ``table`` Query, and edit Target.

--- a/api/handler.go
+++ b/api/handler.go
@@ -16,6 +16,8 @@ type TSQuery struct {
 	Collection string
 	Col        string
 	TimeCol    string
+	MatchField string
+	MatchValue string
 	From       time.Time
 	To         time.Time
 	IntervalMs int
@@ -72,7 +74,7 @@ func (conf *Config) reqQuery(w http.ResponseWriter, r *http.Request) {
 			resbytes = append(resbytes, []byte(",")...)
 		} else if q.Type == "timeserie" {
 			resp := TimeSeriesResponse{Target: v.Target}
-			resp.DataPoint, err = sp.GetTimeSeriesData(q.DB, q.Collection, q.Col, q.TimeCol, q.From, q.To, q.IntervalMs)
+			resp.DataPoint, err = sp.GetTimeSeriesData(q.DB, q.Collection, q.Col, q.TimeCol, q.MatchField, q.MatchValue, q.From, q.To, q.IntervalMs)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -108,6 +110,10 @@ func (q *TSQuery) parseTarget(target string) error {
 		columns := TimeSeriesColumnRegexp(res[2])
 		q.Col = columns[0]
 		q.TimeCol = columns[1]
+		if len(columns) > 2 {
+			q.MatchField = columns[2]
+			q.MatchValue = columns[3]
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
I have a huge db of events from many sensors. I needed to be able to pick them up appart from the same collection. So if specified in the request, the app will match the field against the value from the request.

I've made some update to the API while the old requests should work. I haven't tested field matching with integers or Dates.